### PR TITLE
PROPOSAL: Add Verifier DID to VP Generation API

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -21,6 +21,7 @@
       specStatus: 'base',
       shortName: 'Digital Wallet Conformance Criteria',
       publishDate: "4 Feb 2022",
+      latestVersion: "https://open-credentialing-initiative.github.io/Digital-Wallet-Conformance-Criteria/",
       maxTocLevel: 3,
       logos: [],
       lint: {

--- a/content/index.html
+++ b/content/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv=" Content-Type" content="text/html;charset=utf-8" />
 
   <title>Digital Wallet Conformance Criteria</title>
-  <h2 id="subtitle">v1.0.1</h2>
+  <h2 id="subtitle">v1.0.0</h2>
 
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
   <script type="text/javascript" class="remove">

--- a/content/index.html
+++ b/content/index.html
@@ -13,7 +13,7 @@
   <meta http-equiv=" Content-Type" content="text/html;charset=utf-8" />
 
   <title>Digital Wallet Conformance Criteria</title>
-  <h2 id="subtitle">v1.0.0</h2>
+  <h2 id="subtitle">v1.0.1</h2>
 
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
   <script type="text/javascript" class="remove">

--- a/content/index.html
+++ b/content/index.html
@@ -2474,6 +2474,14 @@
                   </li>
                 </ul>
               </li>
+              <li>
+                <b>verifierDID</b> | <i>string</i> | <b>required</b>
+                <ul>
+                  <li>
+                    The <a>DID</a> that requests a verification of the attached <b>Verifiable Presentation</b>.
+                  </li>
+                </ul>
+              </li>
             </ul>
           </td>
         </tr>


### PR DESCRIPTION
## General
This pull request proposes to add a **required** `verifierDID` value to the VP verification request body in the [Digital Wallet Conformance Criteria](https://open-credentialing-initiative.github.io/Digital-Wallet-Conformance-Criteria). 

## Reasoning
As I see it as of today, OCI is aiming to define architecture-agnostic specifications that gives developers freedom regarding their specific implementations as long as they adhere to the defined specifications. This approach seems to be broken regarding the VP verification API in the [Digital Wallet Conformance Criteria](https://open-credentialing-initiative.github.io/Digital-Wallet-Conformance-Criteria/#api-to-verify-verifiable-presentation-of-atp-credential).

This is very much apparent if the implementation supports holding multiple DIDs over maybe multiple different tenants within a solution. With the current specification, it is not possible to define which entity/ DID requested a VP verification, which may lead to further problematic limitations. Those may include, e.g., not being able to save the result of a VP verification process to the verifying parties tenant/ agent, which may be needed for regulatory purposes (see audit trail).

Interestingly, this approach of adding a DID to the request body is already embraced looking at the VP generation API which allows the correct addressing of which DID (`holderDID`), and therefore maybe which tenant, should generate a VP of the specified credential type. (see [Digital Wallet Conformance VP generation API request body](https://open-credentialing-initiative.github.io/Digital-Wallet-Conformance-Criteria/#api-to-generate-a-verifiable-presentation-of-atp-credential)) 

## Impact

Because the proposed addition of the `verifierDID` being **required**, all existing implementations would need to consider the new value in the request body. If not needed, it can be ignored. Not implementing the specified `verifierDID` will result in other parties not being able to, e.g., maintain their audit trail for VP verification events.

<hl>

This PR is connected to another [PR on the API specification](https://github.com/Open-Credentialing-Initiative/api-specifications/pulls)