### PR TITLE
feat: update trusted issuer registry section

### DIFF
--- a/content/DRAFT/index.html
+++ b/content/DRAFT/index.html
@@ -689,14 +689,21 @@
         </p>
         <ul>
           <li>
-            <a href="https://goerli.etherscan.io/address/0xDfC7aCC61c532350a562018d627c6fe6aBBca5e8" target="_blank" rel="noopener noreferrer">Development (Goerli)</a>
+            <a href="https://goerli.etherscan.io/address/0xDfC7aCC61c532350a562018d627c6fe6aBBca5e8" target="_blank" rel="noopener noreferrer">Development STK-INT (Goerli)</a>
           </li>
           <li>
-            <a href="https://goerli.etherscan.io/address/0x07a79C830352ab30d7C3241F2d16db7e33D1f197" target="_blank" rel="noopener noreferrer">Development (Goerli Sandbox)</a>
+            <a href="https://goerli.etherscan.io/address/0xfAc0eac761d4b589b471e461F247059b2f9A8B85" target="_blank" rel="noopener noreferrer">Development WLT-INT (Goerli)</a>
+          </li>
+          <li>
+            <a href="https://goerli.etherscan.io/address/0x2b219C6e76A8Df00Aa90155620078d56a6e3f26c" target="_blank" rel="noopener noreferrer">Development PBL-INT (Goerli)</a>
           </li>
         </ul>
-        <p>The Goerli Sandbox Contract has been modified to not require any OCI mechanisms to add and remove trusted
-          issuer DIDs. This may be used for testing by anyone who is interested.</p>
+        <p>
+          The development environments are deployed on an Ethereum test network. STK-INT mirrors the production
+          environment and should only be used for testing purposes by approved OCI statekeepers. WLT-INT should be used
+          only by OCI digital wallets for testing purposes without voting processes. PBL-INT is generally open without
+          any restrictions to make quick testing easy.
+        </p>
         <p>In addition to readily deployed versions of the contracts, OCI has also published the source code as well as
           implementation guidelines on GitHub: <a href="https://github.com/Open-Credentialing-Initiative/trusted-issuer-registry" target="_blank" rel="noopener noreferrer">Trusted Issuer Registry</a>.
         </p>
@@ -743,6 +750,11 @@
               </ul>
             </li>
           </ul>
+          <p>
+            A Digital Wallet MAY also subscribe to changes on the Trusted Issuer Registry by listening to events emitted
+            by the contract. This way, the wallet can be notified of changes to the Trusted Issuer Registry and update
+            its local state accordingly.
+          </p>
           <p>
             By deriving this information from the contract, the Digital Wallet SHALL check that the issuer stated within the claims of the respective
             Stakeholder credential matches one of those trusted issuers recorded in the Trusted Issuer Registry.


### PR DESCRIPTION
This PR updates the trusted issuer registry section to reflect the newest testing environment and usage options. (see https://github.com/Open-Credentialing-Initiative/trusted-issuer-registry/pull/4)