### PR TITLE
feat: add new error if revocation status is unclear

### DIFF
--- a/content/DRAFT/index.html
+++ b/content/DRAFT/index.html
@@ -2306,6 +2306,17 @@
           </ul>
         </li>
         <li>
+          The field <b>vp.verifiableCredential.credentialStatus</b> (Revocation of the Verifiable <a>Credential</a>) is
+          evaluated, the revocation checked and concluded to be unclear. This error SHALL be thrown if the revocation
+          status of the Verifiable <a>Credential</a> can not be resolved from the revocation registry and/ or cached
+          data is older than 24 hours.
+          <ul>
+            <li>
+              <b>vc_status_unclear</b>
+            </li>
+          </ul>
+        </li>
+        <li>
           The field <b>vp.verifiableCredential.proof</b> (Proof of the Verifiable <a>Credential</a>) is concluded to be
           invalid
           given the signed body or does not yield a valid or resolvable result.


### PR DESCRIPTION
This PR adds a new error code thrown in case the revocation status can not be resolved. In response to https://github.com/Open-Credentialing-Initiative/Digital-Wallet-Conformance-Criteria/issues/76#issuecomment-1710500742

I created a separate PR for this because the rework of error codes https://github.com/Open-Credentialing-Initiative/Digital-Wallet-Conformance-Criteria/pull/71 is dependent on a different structure for JWT VPs https://github.com/Open-Credentialing-Initiative/schemas/pull/11. This might be a bigger discussion, hence this PR to unblock this specific OCI request.

I have also updated the rework of the error codes to include this new code, so feel free to close this, in case you deem this to be unnecessary.